### PR TITLE
Add locationTable directly to popover in inventory view

### DIFF
--- a/poe_ext/main.js
+++ b/poe_ext/main.js
@@ -528,7 +528,21 @@ function getItemLink(item) {
 				trigger: 'hover',
 				content: function(){
 
-					var html = $('<div class="fit-content" style="width:500px">').append('<div class="pull-left"  style="width:100px"><img src="' + item.rawItem.icon + '" /></div>');
+					var html = $('<div class="fit-content" style="width:500px">')
+
+
+          var left = $('<div class="pull-left"  style="width:100px">')
+              left.append('<img src="' + item.rawItem.icon + '" />');
+
+          var tableContainer = $('<div style="position: absolute; bottom: 25px">');
+          var table = getLocationTable(item, "Inventory");
+          if(table) table.css('display','table'); // I don't like having to set this again
+                                        // but it's better than making the executive decision
+                                        // to refactor how the tables work in the main table
+          tableContainer.append(table);
+
+          left.append(tableContainer);
+          html.append(left);
 
 					if (item.sockets.numSockets > 0) {
 						html.append(displaySockets(item));
@@ -536,10 +550,10 @@ function getItemLink(item) {
 
 					$('<pre class="pull-left">')
 						.append(itemToString(item))
-						.appendTo(html)
-					;
+						.appendTo(html);
 
 					$('<div class="clearfix">').appendTo(html);
+
 					return html;
 				},
 				placement: 'bottom',


### PR DESCRIPTION
![Screen shot 2013-02-17 at 4 18 43 PM](https://f.cloud.github.com/assets/191920/165602/67f09ebc-7958-11e2-871a-1b9160ead37a.png)

I found myself consistently looking for the location table when I hovered over an item to see its stats rather than having to hover, close the hover, and hit show/hide. 

So I added a copy of the location table to the popover, quick and simple. 

No errors, checkout my fork and test if you need to. 

In the future I may suggest caching the location tables for each item instead of recreating the html each time getLocationTable is called. Not sure if it's even much of a performance impact though. 
